### PR TITLE
Include React import statement in basic component example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ and add a script to your package.json like this:
 After that, your `src/App.js` is your main entry point. All you need is to do is export a basic component to get started:
 
 ```js
+import React from "react"
+
 export default () => <div>Welcome to Rogue.js!</div>
 ```
 


### PR DESCRIPTION
Someone could copy and paste the basic component example and receive an error that React wasn't included. I think it's best the examples are explicit to prevent frustrations like this.